### PR TITLE
TemperatureWebPanel.ino Print "Yún" and not "Y�n", "degrees C" to "ºC"

### DIFF
--- a/libraries/Bridge/examples/TemperatureWebPanel/TemperatureWebPanel.ino
+++ b/libraries/Bridge/examples/TemperatureWebPanel/TemperatureWebPanel.ino
@@ -102,11 +102,11 @@ void loop() {
       // convert the millivolts to temperature celsius:
       float temperature = (voltage - 500) / 10;
       // print the temperature:
-      client.print("Current time on the Yún: ");
+      client.print("Current time on the Y&uacuten: ");
       client.println(timeString);
       client.print("<br>Current temperature: ");
       client.print(temperature);
-      client.print(" degrees C");
+      client.print(" &degC");
       client.print("<br>This sketch has been running since ");
       client.print(startString);
       client.print("<br>Hits so far: ");


### PR DESCRIPTION
Hi, just got a Yún few days ago and noticed that when testing stuff, just cosmetic.

Thanks.